### PR TITLE
[rs] Implement `emit_define_font_any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Rust
 
-- **[Feature]** Implement emitters for the following tags: `DefineFontAlignZones`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
+- **[Feature]** Implement emitters for the following tags: `DefineFont`, `DefineFontAlignZones`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
 - **[Feature]** Implement `emit_movie`.
 
 ### Typescript
@@ -10,4 +10,4 @@
 - **[Breaking change]** Update to `swf-tree@0.6.0`.
 - **[Fix]** Fix `emitFontAlignmentZone` flags.
 - **[Fix]** Fix `emitDefineMorphShapeAny` flags.
-- **[Fix]** Use shorter bit count for shape styles.
+- **[Fix]** Use shorter bit count for shape styles and glyphs.

--- a/rs/src/shape.rs
+++ b/rs/src/shape.rs
@@ -18,6 +18,22 @@ pub enum ShapeVersion {
   Shape4,
 }
 
+pub(crate) fn emit_glyph<W: io::Write>(writer: &mut W, value: &ast::Glyph) -> io::Result<()> {
+  let mut bits_writer = BitsWriter::new(Vec::new());
+  emit_glyph_bits(&mut bits_writer, value)?;
+  writer.write_all(&bits_writer.into_inner()?)
+}
+
+pub(crate) fn emit_glyph_bits<W: WriteBits>(writer: &mut W, value: &ast::Glyph) -> io::Result<()> {
+  // TODO: Check how to determine the bit count (scan records?)
+  let fill_bits: u32 = 1; // 2 styles (empty and filled) -> 1 bit
+  let line_bits: u32 = 0; // no line styles
+  writer.write_u32_bits(4, fill_bits)?;
+  writer.write_u32_bits(4, line_bits)?;
+  // TODO: Check which shape version to use
+  emit_shape_record_string_bits(writer, &value.records, fill_bits, line_bits, ShapeVersion::Shape1)
+}
+
 pub(crate) fn emit_shape<W: io::Write>(writer: &mut W, value: &ast::Shape, version: ShapeVersion) -> io::Result<()> {
   let mut bits_writer = BitsWriter::new(Vec::new());
   emit_shape_bits(&mut bits_writer, value, version)?;

--- a/rs/src/text.rs
+++ b/rs/src/text.rs
@@ -3,9 +3,41 @@ use std::io;
 
 use swf_tree as ast;
 
-use crate::primitives::{emit_le_f16, emit_u8};
+use crate::basic_data_types::emit_rect;
+use crate::primitives::{emit_le_f16, emit_le_i16, emit_le_u16, emit_le_u32, emit_u8};
+use crate::shape::emit_glyph;
 
-pub fn emit_font_alignment_zone<W: io::Write>(writer: &mut W, value: &ast::text::FontAlignmentZone) -> io::Result<()> {
+// TODO: Remove unused variants (`dead_code` should not be allowed)
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum DefineFontVersion {
+  Font1,
+  Font2,
+  Font3,
+  Font4,
+}
+
+pub(crate) fn csm_table_hint_to_code(value: ast::text::CsmTableHint) -> u8 {
+  match value {
+    ast::text::CsmTableHint::Thin => 0,
+    ast::text::CsmTableHint::Medium => 1,
+    ast::text::CsmTableHint::Thick => 2,
+  }
+}
+
+pub(crate) fn emit_language_code<W: io::Write>(writer: &mut W, value: ast::LanguageCode) -> io::Result<()> {
+  let code: u8 = match value {
+    ast::LanguageCode::Auto => 0,
+    ast::LanguageCode::Latin => 1,
+    ast::LanguageCode::Japanese => 2,
+    ast::LanguageCode::Korean => 3,
+    ast::LanguageCode::SimplifiedChinese => 4,
+    ast::LanguageCode::TraditionalChinese => 5,
+  };
+  emit_u8(writer, code)
+}
+
+pub(crate) fn emit_font_alignment_zone<W: io::Write>(writer: &mut W, value: &ast::text::FontAlignmentZone) -> io::Result<()> {
   assert!(value.data.len() < 256);
 
   emit_u8(writer, value.data.len().try_into().unwrap())?;
@@ -18,4 +50,60 @@ pub fn emit_font_alignment_zone<W: io::Write>(writer: &mut W, value: &ast::text:
     | (if value.has_y { 1 << 1 } else { 0 });
   // Skip bits [2, 7]
   emit_u8(writer, flags)
+}
+
+pub(crate) fn emit_offset_glyphs<W: io::Write>(writer: &mut W, value: &[ast::Glyph]) -> io::Result<bool> {
+  let mut end_offsets: Vec<usize> = Vec::with_capacity(value.len());
+  let mut glyph_writer: Vec<u8> = Vec::new();
+  for glyph in value {
+    emit_glyph(&mut glyph_writer, glyph)?;
+    end_offsets.push(glyph_writer.len());
+  }
+
+  let offset_table_len = end_offsets.len() + 1;
+  let short_offset_table_size = offset_table_len * std::mem::size_of::<u16>();
+  let max_offset_with_short_table = short_offset_table_size + glyph_writer.len();
+
+  let use_wide_offsets = max_offset_with_short_table > usize::from(u16::max_value());
+
+  if use_wide_offsets {
+    let wide_offset_table_size = offset_table_len * std::mem::size_of::<u32>();
+
+    emit_le_u32(writer, wide_offset_table_size.try_into().unwrap())?;
+    for end_offset in end_offsets {
+      emit_le_u32(writer, (wide_offset_table_size + end_offset).try_into().unwrap())?;
+    }
+  } else {
+    emit_le_u16(writer, short_offset_table_size.try_into().unwrap())?;
+    for end_offset in end_offsets {
+      emit_le_u16(writer, (short_offset_table_size + end_offset).try_into().unwrap())?;
+    }
+  }
+
+  writer.write_all(&glyph_writer)?;
+
+  Ok(use_wide_offsets)
+}
+
+pub(crate) fn emit_font_layout<W: io::Write>(writer: &mut W, value: &ast::text::FontLayout) -> io::Result<()> {
+  emit_le_u16(writer, value.ascent)?;
+  emit_le_u16(writer, value.descent)?;
+  emit_le_u16(writer, value.leading)?;
+  for advance in &value.advances {
+    emit_le_u16(writer, *advance)?;
+  }
+  for bound in &value.bounds {
+    emit_rect(writer, bound)?;
+  }
+  emit_le_u16(writer, value.kerning.len().try_into().unwrap())?;
+  for kerning_record in &value.kerning {
+    emit_kerning_record(writer, kerning_record)?;
+  }
+  Ok(())
+}
+
+pub(crate) fn emit_kerning_record<W: io::Write>(writer: &mut W, value: &ast::text::KerningRecord) -> io::Result<()> {
+  emit_le_u16(writer, value.left)?;
+  emit_le_u16(writer, value.right)?;
+  emit_le_i16(writer, value.adjustment)
 }

--- a/ts/src/lib/emitters/shape.ts
+++ b/ts/src/lib/emitters/shape.ts
@@ -36,9 +36,9 @@ export function emitGlyph(byteStream: WritableByteStream, value: Glyph): void {
 }
 
 export function emitGlyphBits(bitStream: WritableBitStream, value: Glyph): void {
-  // TODO: We use the maximum at the moment, but we should check how to determine the bit count
-  const fillBits: UintSize = 0b1111;
-  const lineBits: UintSize = 0b1111;
+  // TODO: Check how to determine the bit count (scan records?)
+  const fillBits: UintSize = 0b0001; // 2 styles (empty and filled) -> 1 bit
+  const lineBits: UintSize = 0b0000; // no line styles
   bitStream.writeUint32Bits(4, fillBits);
   bitStream.writeUint32Bits(4, lineBits);
   // TODO: Check which shape version to use


### PR DESCRIPTION
This commit adds Rust support for `DefineFont` tags. It also includes minor fixes to the Typescript implementation.