### PR TITLE
[rs] Implement `emit_define_font_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Rust
 
-- **[Feature]** Implement emitters for the following tags: `DefineFont`, `DefineFontAlignZones`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
+- **[Feature]** Implement emitters for the following tags: `DefineFont`, `DefineFontAlignZones`, `DefineFontName`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
 - **[Feature]** Implement `emit_movie`.
 
 ### Typescript

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -58,6 +58,10 @@ pub fn emit_tag<W: io::Write>(writer: &mut W, value: &ast::Tag, swf_version: u8)
       emit_define_font_align_zones(&mut tag_writer, tag)?;
       73
     }
+    ast::Tag::DefineFontName(ref tag) => {
+      emit_define_font_name(&mut tag_writer, tag)?;
+      88
+    }
     ast::Tag::DefineMorphShape(ref tag) => {
       match emit_define_morph_shape_any(&mut tag_writer, tag)? {
         MorphShapeVersion::MorphShape1 => 46,
@@ -181,6 +185,12 @@ pub fn emit_define_font_align_zones<W: io::Write>(writer: &mut W, value: &ast::t
     emit_font_alignment_zone(writer, zone)?;
   }
   Ok(())
+}
+
+pub fn emit_define_font_name<W: io::Write>(writer: &mut W, value: &ast::tags::DefineFontName) -> io::Result<()> {
+  emit_le_u16(writer, value.font_id)?;
+  emit_c_string(writer, &value.name)?;
+  emit_c_string(writer, &value.copyright)
 }
 
 pub fn emit_define_morph_shape_any<W: io::Write>(writer: &mut W, value: &ast::tags::DefineMorphShape) -> io::Result<MorphShapeVersion> {


### PR DESCRIPTION
This commit adds Rust support for `DefineFontName` tags.