### PR TITLE
[rs] Implement `emit_csm_text_settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Rust
 
-- **[Feature]** Implement emitters for the following tags: `DefineFont`, `DefineFontAlignZones`, `DefineFontName`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DefineText`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
+- **[Feature]** Implement emitters for the following tags: `CsmTextSettings`, `DefineFont`, `DefineFontAlignZones`, `DefineFontName`, `DefineMorphShape`, `DefineSceneAndFrameLabelData`, `DefineShape`, `DefineSprite`, `DefineText`, `DoAction`, `FileAttributes`, `Metadata`, `PlaceObject`, `RemoveObject`, `SetBackgroundColor`, `ShowFrame`.
 - **[Feature]** Implement `emit_movie`.
 
 ### Typescript
@@ -10,5 +10,5 @@
 - **[Breaking change]** Update to `swf-tree@0.6.0`.
 - **[Fix]** Fix `emitFontAlignmentZone` flags.
 - **[Fix]** Fix `emitDefineMorphShapeAny` flags.
-- **[Fix]** Use shorter bit count for shape styles and glyphs.
+- **[Fix]** Use shorter bit counts for shape styles and glyphs.
 - **[Fix]** Fix `emitTextRecord` flags.

--- a/rs/src/text.rs
+++ b/rs/src/text.rs
@@ -44,6 +44,21 @@ pub(crate) fn emit_language_code<W: io::Write>(writer: &mut W, value: ast::Langu
   emit_u8(writer, code)
 }
 
+pub(crate) fn grid_fitting_to_code(value: ast::text::GridFitting) -> u8 {
+  match value {
+    ast::text::GridFitting::None => 0,
+    ast::text::GridFitting::Pixel => 1,
+    ast::text::GridFitting::SubPixel => 2,
+  }
+}
+
+pub(crate) fn text_renderer_to_code(value: ast::text::TextRenderer) -> u8 {
+  match value {
+    ast::text::TextRenderer::Advanced => 1,
+    ast::text::TextRenderer::Normal => 0,
+  }
+}
+
 pub(crate) fn emit_text_record_string<W: io::Write>(writer: &mut W, value: &[ast::text::TextRecord], index_bits: u32, advance_bits: u32, with_alpha: bool) -> io::Result<()> {
   for record in value {
     emit_text_record(writer, record, index_bits, advance_bits, with_alpha)?;

--- a/ts/src/lib/emitters/text.ts
+++ b/ts/src/lib/emitters/text.ts
@@ -5,19 +5,6 @@ import { Glyph, LanguageCode, text } from "swf-tree";
 import { emitRect, emitSRgb8, emitStraightSRgba8 } from "./basic-data-types";
 import { emitGlyph } from "./shape";
 
-export function emitGridFittingBits(bitStream: WritableBitStream, value: text.GridFitting): void {
-  const VALUE_TO_CODE: Map<text.GridFitting, Uint3> = new Map([
-    [text.GridFitting.None, 0 as Uint3],
-    [text.GridFitting.Pixel, 1 as Uint3],
-    [text.GridFitting.SubPixel, 2 as Uint3],
-  ]);
-  const code: Uint3 | undefined = VALUE_TO_CODE.get(value);
-  if (code === undefined) {
-    throw new Incident("Unexpected value");
-  }
-  bitStream.writeUint32Bits(3, code);
-}
-
 export function emitLanguageCode(byteStream: WritableByteStream, value: LanguageCode): void {
   const VALUE_TO_CODE: Map<LanguageCode, Uint8> = new Map([
     [LanguageCode.Auto, 0],
@@ -34,16 +21,29 @@ export function emitLanguageCode(byteStream: WritableByteStream, value: Language
   byteStream.writeUint8(code);
 }
 
-export function emitTextRendererBits(bitStream: WritableBitStream, value: text.TextRenderer): void {
+export function gridFittingToCode(value: text.GridFitting): Uint3 {
+  const VALUE_TO_CODE: Map<text.GridFitting, Uint3> = new Map([
+    [text.GridFitting.None, 0 as Uint3],
+    [text.GridFitting.Pixel, 1 as Uint3],
+    [text.GridFitting.SubPixel, 2 as Uint3],
+  ]);
+  const code: Uint3 | undefined = VALUE_TO_CODE.get(value);
+  if (code === undefined) {
+    throw new Incident("Unexpected value");
+  }
+  return code;
+}
+
+export function textRendererToCode(value: text.TextRenderer): Uint2 {
   const VALUE_TO_CODE: Map<text.TextRenderer, Uint2> = new Map([
-    [text.TextRenderer.Normal, 0 as Uint2],
     [text.TextRenderer.Advanced, 1 as Uint2],
+    [text.TextRenderer.Normal, 0 as Uint2],
   ]);
   const code: Uint2 | undefined = VALUE_TO_CODE.get(value);
   if (code === undefined) {
     throw new Incident("Unexpected value");
   }
-  bitStream.writeUint32Bits(2, code);
+  return code;
 }
 
 export function emitTextRecordString(


### PR DESCRIPTION
This commit adds Rust support for `CsmTextSettings` tags. It also includes minor fixes to the Typescript implementation.