### PR TITLE
[rs] Implement emitter for `DefineDynamicText` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ### Rust
 
-- **[Feature]** Implement emitters for the following tags: `DefineBitmap`, `DefineButton`, `DefineSound`, `ExportAssets`, `FrameLabel`.
+- **[Feature]** Implement emitters for the following tags: `DefineBitmap`, `DefineButton`, `DefineDynamicText`, `DefineSound`, `ExportAssets`, `FrameLabel`.
 - **[Internal]** Use exhaustive match in `emit_tag`.
 
 ### Typescript
 
 - **[Fix]** Use shorter bit count for `ColorTransform` and `ColorTransformWithAlpha`.
 - **[Fix]** Fix `ButtonCond` flags.
+- **[Fix]** Fix `DefineDynamicText` layout support.
 
 # 0.3.0 (2019-04-24)
 

--- a/rs/src/text.rs
+++ b/rs/src/text.rs
@@ -182,3 +182,13 @@ pub(crate) fn emit_kerning_record<W: io::Write>(writer: &mut W, value: &ast::tex
   emit_le_u16(writer, value.right)?;
   emit_le_i16(writer, value.adjustment)
 }
+
+pub(crate) fn emit_text_alignment<W: io::Write>(writer: &mut W, value: ast::text::TextAlignment) -> io::Result<()> {
+  let code: u8 = match value {
+    ast::text::TextAlignment::Center => 2,
+    ast::text::TextAlignment::Justify => 3,
+    ast::text::TextAlignment::Left => 0,
+    ast::text::TextAlignment::Right => 1,
+  };
+  emit_u8(writer, code)
+}


### PR DESCRIPTION
This commit adds Rust support for `DefineDynamicText` tags. It also includes minor fixes to the Typescript implementation.