### PR TITLE
[rs] Fix `MorphLineStyle2` with solid fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Next
 
+- **[Fix]** Zero-out style bits in morph shape end state.
+
 ### Rust
 
 - **[Feature]** Implement emitters for the following tags: `DefineBitmap`, `DefineButton`, `DefineDynamicText`, `DefineJpegTables`, `DefineSound`, `ExportAssets`, `FrameLabel`.
 - **[Fix]** Fix `LineStyle2` and `MorphLineStyle2` flags.
+- **[Fix]** Fix `MorphLineStyle2` with solid fill.
 - **[Internal]** Use exhaustive match in `emit_tag`.
 
 ### Typescript

--- a/rs/src/morph_shape.rs
+++ b/rs/src/morph_shape.rs
@@ -31,10 +31,9 @@ pub(crate) fn emit_morph_shape<W: io::Write>(writer: &mut W, value: &ast::MorphS
 
   let mut bits_writer = BitsWriter::new(inner_bits_writer);
 
-  // TODO: We should be able to skip these bits (no styles used for the endRecords)
-  // We copy the bits from the start shape to match the behavior in `morph-rotating-square`.
-  bits_writer.write_u32_bits(4, fill_bits)?;
-  bits_writer.write_u32_bits(4, line_bits)?;
+  // `0` for the style bits: there are no style changes in the end state.
+  bits_writer.write_u32_bits(4, 0)?;
+  bits_writer.write_u32_bits(4, 0)?;
   emit_morph_shape_end_record_string_bits(&mut bits_writer,&value.records)?;
 
   emit_le_u32(writer, start_size.try_into().unwrap())?;
@@ -273,7 +272,7 @@ pub(crate) fn emit_morph_line_style2<W: io::Write + ?Sized>(writer: &mut W, valu
   }
 
   match &value.fill {
-    ast::MorphFillStyle::Solid(ref style) => emit_straight_s_rgba8(writer, style.color),
+    ast::MorphFillStyle::Solid(ref style) => emit_morph_solid_fill(writer, style),
     style => emit_morph_fill_style(writer, style)
   }
 }

--- a/rs/src/shape.rs
+++ b/rs/src/shape.rs
@@ -300,7 +300,7 @@ pub(crate) fn emit_line_style2<W: io::Write + ?Sized>(writer: &mut W, value: &as
   }
 
   match &value.fill {
-    ast::FillStyle::Solid(ref style) => emit_straight_s_rgba8(writer, style.color),
+    ast::FillStyle::Solid(ref style) => emit_solid_fill(writer, style, true),
     style => emit_fill_style(writer, style, true)
   }
 }

--- a/ts/src/lib/emitters/morph-shape.ts
+++ b/ts/src/lib/emitters/morph-shape.ts
@@ -51,10 +51,9 @@ export function emitMorphShapeBits(
 
   const result: UintSize = bitStream.bytePos;
 
-  // TODO: We should be able to skip these bits (no styles used for the endRecords)
-  // We copy the bits from the start shape to match the behavior in `morph-rotating-square`.
-  bitStream.writeUint32Bits(4, fillBits);
-  bitStream.writeUint32Bits(4, lineBits);
+  // `0` for style bits: there are no style changes in the end state.
+  bitStream.writeUint32Bits(4, 0);
+  bitStream.writeUint32Bits(4, 0);
   emitMorphShapeEndRecordStringBits(bitStream, value.records);
   bitStream.align();
 


### PR DESCRIPTION
This commit also uses zeroed-out style bits for the morph-shape end state.