### PR TITLE
[all] Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.3.1 (2019-04-26)
 
 - **[Fix]** Zero-out style bits in morph shape end state.
 - **[Fix]** Force long-form tag header for the following concrete tags: `DefineBits`, `DefineBitsJPEG2`, `DefineBitsJPEG3`, `DefineBitsLossless`, `DefineBitsLossless2`, `DefineBitsJPEG4` and `SoundStreamBlock`.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "swf-emitter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-emitter"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF emitter"
 documentation = "https://github.com/open-flash/swf-emitter"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-emitter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SWF files emitter",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Fix]** Zero-out style bits in morph shape end state.
- **[Fix]** Force long-form tag header for the following concrete tags: `DefineBits`, `DefineBitsJPEG2`, `DefineBitsJPEG3`, `DefineBitsLossless`, `DefineBitsLossless2`, `DefineBitsJPEG4` and `SoundStreamBlock`.

### Rust

- **[Feature]** Implement emitters for the following tags: `DefineBitmap`, `DefineButton`, `DefineDynamicText`, `DefineJpegTables`, `DefineSound`, `ExportAssets`, `FrameLabel`.
- **[Fix]** Fix `LineStyle2` and `MorphLineStyle2` flags.
- **[Fix]** Fix `MorphLineStyle2` with solid fill.
- **[Internal]** Use exhaustive match in `emit_tag`.

### Typescript

- **[Fix]** Use shorter bit count for `ColorTransform` and `ColorTransformWithAlpha`.
- **[Fix]** Fix `ButtonCond` flags.
- **[Fix]** Fix `DefineDynamicText` layout support.