### PR TITLE
[all] Refactor consumer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Breaking change]** Update to `swf-types@0.10.0`.
+- **[Breaking change]** Refactor consumer API. The main export now consists in two simple functions `emitSwf` and `emitTag`, both return a byte array.
 - **[Fix]** Add support for `DefineButton1`.
 - **[Fix]** Add support for `DefineButtonSound`.
 - **[Fix]** Add support for `StartSound`.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ this is a bug. The same AST always produces the same output.
 
 ## Status
 
-The implementation is still incomplete. About half of the tags are supported.
-
-The Typescript implementation is currently ahead of the Rust implementation.
-Getting them in sync is part of the current work.
-
+Most of the tags are implemented but some are still missing.
 Help is welcome to complete the emitter.
 
 ## Contributing

--- a/rs/README.md
+++ b/rs/README.md
@@ -15,13 +15,12 @@ Converts [`swf-types` movies][swf-types] to bytes.
 ## Usage
 
 ```rust
-use swf_emitter;
+use swf_emitter::emit_swf;
 use swf_types::{CompressionMethod, Movie};
 
 fn main() {
   let movie: Movie = ...;
-  let mut bytes = Vec::new();
-  emit_movie(&mut bytes, &movie, CompressionMethod::None)
+  let swf_bytes = emit_swf(&movie, CompressionMethod::None)
     .expect("Failed to emit movie");
 }
 ```

--- a/rs/src/movie.rs
+++ b/rs/src/movie.rs
@@ -8,14 +8,14 @@ use swf_types as ast;
 
 const SWF_SIGNATURE_SIZE: usize = 8;
 
-pub fn emit_movie<W: io::Write>(
+pub fn emit_swf<W: io::Write>(
   writer: &mut W,
   value: &ast::Movie,
   compression_method: ast::CompressionMethod,
 ) -> io::Result<()> {
-  let mut payload_writer = Vec::new();
-  emit_payload(&mut payload_writer, value)?;
-  let uncompressed_file_length = SWF_SIGNATURE_SIZE + payload_writer.len();
+  let mut movie_writer = Vec::new();
+  emit_movie(&mut movie_writer, value)?;
+  let uncompressed_file_length = SWF_SIGNATURE_SIZE + movie_writer.len();
   let signature = ast::SwfSignature {
     compression_method,
     swf_version: value.header.swf_version,
@@ -25,7 +25,7 @@ pub fn emit_movie<W: io::Write>(
   match compression_method {
     ast::CompressionMethod::Deflate => unimplemented!(),
     ast::CompressionMethod::Lzma => unimplemented!(),
-    ast::CompressionMethod::None => writer.write_all(&payload_writer),
+    ast::CompressionMethod::None => writer.write_all(&movie_writer),
   }
 }
 
@@ -46,7 +46,7 @@ pub fn emit_compression_method<W: io::Write>(writer: &mut W, value: ast::Compres
   writer.write_all(code)
 }
 
-pub fn emit_payload<W: io::Write>(writer: &mut W, value: &ast::Movie) -> io::Result<()> {
+pub fn emit_movie<W: io::Write>(writer: &mut W, value: &ast::Movie) -> io::Result<()> {
   emit_header(writer, &value.header)?;
   emit_tag_string(writer, &value.tags, value.header.swf_version)
 }

--- a/ts/README.md
+++ b/ts/README.md
@@ -18,11 +18,11 @@ Converts [`swf-types` movies][swf-types] to bytes.
 import fs from "fs";
 import { CompressionMethod } from "swf-types";
 import { Movie } from "swf-types/movie";
-import { movieToBytes } from "swf-emitter";
+import { emitSwf } from "swf-emitter";
 
 function main(): void {
-  const movie: Movie = fs.readFileSync("ast.json");
-  const bytes: Uint8Array = movieToBytes(movie, CompressionMethod.Deflate);
+  const movie: Movie = fs.readFileSync("movie.json");
+  const bytes: Uint8Array = emitSwf(movie, CompressionMethod.Deflate);
   fs.writeFileSync("movie.swf", bytes);
 }
 

--- a/ts/src/lib/emitters/movie.ts
+++ b/ts/src/lib/emitters/movie.ts
@@ -8,9 +8,9 @@ import { emitTagString } from "./tags";
 
 const SWF_SIGNATURE_SIZE: UintSize = 8;
 
-export function emitMovie(byteStream: WritableByteStream, value: Movie, compressionMethod: CompressionMethod): void {
+export function emitSwf(byteStream: WritableByteStream, value: Movie, compressionMethod: CompressionMethod): void {
   const movieStream: WritableByteStream = new WritableStream();
-  emitPayload(movieStream, value);
+  emitMovie(movieStream, value);
   const uncompressedFileLength: UintSize = SWF_SIGNATURE_SIZE + movieStream.bytePos;
   const signature: SwfSignature = {
     compressionMethod,
@@ -53,7 +53,7 @@ export function emitCompressionMethod(byteStream: WritableByteStream, value: Com
   byteStream.writeBytes(chunk);
 }
 
-function emitPayload(byteStream: WritableByteStream, value: Movie): void {
+function emitMovie(byteStream: WritableByteStream, value: Movie): void {
   emitHeader(byteStream, value.header);
   emitTagString(byteStream, value.tags, value.header.swfVersion);
 }

--- a/ts/src/lib/index.ts
+++ b/ts/src/lib/index.ts
@@ -1,15 +1,40 @@
 import { WritableByteStream, WritableStream } from "@open-flash/stream";
+import { Uint8 } from "semantic-types";
 import * as ast from "swf-types";
 import { CompressionMethod } from "swf-types";
-import { emitMovie } from "./emitters/movie";
+import { emitSwf as emitSwfStream } from "./emitters/movie";
+import { emitTag as emitTagStream } from "./emitters/tags";
 
 export { ast };
 
-export function movieToBytes(
+/**
+ * Emits an SWF movie as a byte array.
+ *
+ * @param value SWF movie to emit.
+ * @param compressionMethod Compression method for the SWF payload.
+ * @returns Corresponding byte array.
+ */
+export function emitSwf(
   value: ast.Movie,
   compressionMethod: CompressionMethod = CompressionMethod.None,
 ): Uint8Array {
   const stream: WritableByteStream = new WritableStream();
-  emitMovie(stream, value, compressionMethod);
+  emitSwfStream(stream, value, compressionMethod);
+  return stream.getBytes();
+}
+
+/**
+ * Emits an SWF tag as a byte array.
+ *
+ * @param value SWF tag to emit.
+ * @param swfVersion SWF version to use for tags sensible to the version.
+ * @returns Corresponding byte array.
+ */
+export function emitTag(
+  value: ast.Tag,
+  swfVersion: Uint8,
+): Uint8Array {
+  const stream: WritableByteStream = new WritableStream();
+  emitTagStream(stream, value, swfVersion);
   return stream.getBytes();
 }

--- a/ts/src/test/movies.spec.ts
+++ b/ts/src/test/movies.spec.ts
@@ -6,7 +6,7 @@ import sysPath from "path";
 import { parseSwf } from "swf-parser";
 import { CompressionMethod } from "swf-types";
 import { $Movie, Movie } from "swf-types/movie";
-import { movieToBytes } from "../lib";
+import { emitSwf } from "../lib";
 import meta from "./meta.js";
 import { readTextFile } from "./utils";
 
@@ -30,7 +30,7 @@ describe("movies", function () {
       const valueJson: string = await readTextFile(sample.astPath);
       const value: Movie = $Movie.read(JSON_READER, valueJson);
 
-      const actualBytes: Uint8Array = movieToBytes(value, CompressionMethod.None);
+      const actualBytes: Uint8Array = emitSwf(value, CompressionMethod.None);
 
       fs.writeFileSync(sysPath.join(MOVIE_SAMPLES_ROOT, sample.name, "local-main.ts.swf"), actualBytes);
 


### PR DESCRIPTION
The main export now consists in two simple functions `emitSwf` and `emitTag`, both return a byte array. This mirrors the parser API.