### PR TITLE
[Rust] Add optional support for deflate and LZMA compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Next
+
+## Rust
+
+- **[Breaking Change]** `emit_swf` now returns `Result<(), SwfEmitError>`.
+- **[Change]** Unsupported compression methods no longer panic, they return an error instead. 
+
 # 0.13.0 (2021-07-24)
 
 ## Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[Breaking Change]** `emit_swf` now returns `Result<(), SwfEmitError>`.
 - **[Change]** Unsupported compression methods no longer panic, they return an error instead.
 - **[Feature]** Add support for DEFLATE compression with the `miniz_oxide` crate.
+- **[Feature]** Add support for LZMA compression with the `lzma-rs` crate.
 
 # 0.13.0 (2021-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Rust
 
 - **[Breaking Change]** `emit_swf` now returns `Result<(), SwfEmitError>`.
-- **[Change]** Unsupported compression methods no longer panic, they return an error instead. 
+- **[Change]** Unsupported compression methods no longer panic, they return an error instead.
+- **[Feature]** Add support for DEFLATE compression with the `miniz_oxide` crate.
 
 # 0.13.0 (2021-07-24)
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nom"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +264,7 @@ version = "0.13.0"
 dependencies = [
  "byteorder",
  "half",
+ "miniz_oxide",
  "serde_json",
  "swf-fixed",
  "swf-parser",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -264,6 +264,7 @@ version = "0.13.0"
 dependencies = [
  "byteorder",
  "half",
+ "lzma-rs",
  "miniz_oxide",
  "serde_json",
  "swf-fixed",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -15,11 +15,16 @@ edition = "2018"
 name = "swf_emitter"
 path = "src/lib.rs"
 
+[features]
+default = ["deflate"]
+deflate = ["miniz_oxide"]
+
 [dependencies]
 byteorder = "1.4.3"
 half = "1.7.1"
 swf-types = "0.13.0"
 swf-fixed = "0.1.5"
+miniz_oxide = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.64"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -16,8 +16,9 @@ name = "swf_emitter"
 path = "src/lib.rs"
 
 [features]
-default = ["deflate"]
+default = ["deflate", "lzma"]
 deflate = ["miniz_oxide"]
+lzma = ["lzma-rs"]
 
 [dependencies]
 byteorder = "1.4.3"
@@ -25,6 +26,7 @@ half = "1.7.1"
 swf-types = "0.13.0"
 swf-fixed = "0.1.5"
 miniz_oxide = { version = "0.5.1", optional = true }
+lzma-rs = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.64"

--- a/rs/README.md
+++ b/rs/README.md
@@ -30,6 +30,7 @@ fn main() {
 SWF compression is provided by the following features, enabled by default:
 
 - `deflate`: enable support for `CompressionMethod::Deflate`, using the [`miniz_oxide`](https://github.com/Frommi/miniz_oxide) crate.
+- `lzma`: enable support for `CompressionMethod::Lzma`, using the [`lzma-rs`](https://github.com/gendx/lzma-rs) crate.
 
 Disabling these features will cause `emit_swf` to return an error when passed the corresponding `CompressionMethod`.
 

--- a/rs/README.md
+++ b/rs/README.md
@@ -25,6 +25,14 @@ fn main() {
 }
 ```
 
+## Features
+
+SWF compression is provided by the following features, enabled by default:
+
+- `deflate`: enable support for `CompressionMethod::Deflate`, using the [`miniz_oxide`](https://github.com/Frommi/miniz_oxide) crate.
+
+Disabling these features will cause `emit_swf` to return an error when passed the corresponding `CompressionMethod`.
+
 ## Contributing
 
 This repo uses Git submodules for its test samples:

--- a/rs/src/error.rs
+++ b/rs/src/error.rs
@@ -1,0 +1,29 @@
+use std::fmt;
+use std::error::Error;
+use std::io;
+
+use swf_types::CompressionMethod;
+
+#[derive(Debug)]
+pub enum SwfEmitError {
+    Io(io::Error),
+    UnsupportedCompression(CompressionMethod),
+}
+
+impl Error for SwfEmitError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SwfEmitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => fmt::Display::fmt(err, f),
+            Self::UnsupportedCompression(method) => write!(f, "Unsupported compression method: {:?}", method),
+        }
+    }
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -21,7 +21,10 @@ pub use error::SwfEmitError;
 
 pub fn emit_swf(value: &Movie, compression_method: CompressionMethod) -> Result<Vec<u8>, SwfEmitError> {
   let mut swf_writer: Vec<u8> = Vec::new();
-  write_swf(&mut swf_writer, value, compression_method)?;
+  match compression_method {
+    CompressionMethod::None => crate::movie::emit_uncompressed_swf_to_buf(&mut swf_writer, value)?,
+    _ => write_swf(&mut swf_writer, value, compression_method)?,
+  }
   Ok(swf_writer)
 }
 

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod basic_data_types;
 pub mod bit_count;
 pub mod button;
 pub mod display;
+mod error;
 pub mod gradient;
 pub mod io_bits;
 pub mod morph_shape;
@@ -16,7 +17,9 @@ use crate::movie::emit_swf as write_swf;
 use crate::tags::emit_tag as write_tag;
 use swf_types::{CompressionMethod, Movie, Tag};
 
-pub fn emit_swf(value: &Movie, compression_method: CompressionMethod) -> std::io::Result<Vec<u8>> {
+pub use error::SwfEmitError;
+
+pub fn emit_swf(value: &Movie, compression_method: CompressionMethod) -> Result<Vec<u8>, SwfEmitError> {
   let mut swf_writer: Vec<u8> = Vec::new();
   write_swf(&mut swf_writer, value, compression_method)?;
   Ok(swf_writer)

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -65,6 +65,8 @@ mod tests {
       (CompressionMethod::None, "local-main.rs.swf"),
       #[cfg(feature="deflate")]
       (CompressionMethod::Deflate, "local-main-deflate.rs.swf"),
+      #[cfg(feature="lzma")]
+      (CompressionMethod::Lzma, "local-main-lzma.rs.swf"),
     ];
 
     for (method, filename) in COMPRESSION_METHODS {

--- a/rs/src/movie.rs
+++ b/rs/src/movie.rs
@@ -18,6 +18,9 @@ pub fn emit_swf<W: io::Write>(
     ast::CompressionMethod::None => W::write_all,
     #[cfg(feature="deflate")]
     ast::CompressionMethod::Deflate => write_bytes_deflate,
+    #[cfg(feature="lzma")]
+    ast::CompressionMethod::Lzma => write_bytes_lzma,
+    #[allow(unreachable_patterns)]
     method => return Err(SwfEmitError::UnsupportedCompression(method)),
   };
 
@@ -32,6 +35,11 @@ pub fn emit_swf<W: io::Write>(
 
   emit_swf_signature(writer, &signature).map_err(SwfEmitError::Io)?;
   write_movie_fn(writer, &movie_bytes).map_err(SwfEmitError::Io)
+}
+
+#[cfg(feature="lzma")]
+fn write_bytes_lzma<W: io::Write>(writer: &mut W, mut bytes: &[u8]) -> io::Result<()> {
+  lzma_rs::lzma_compress(&mut bytes, writer)
 }
 
 #[cfg(feature="deflate")]

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -572,8 +572,8 @@ pub fn emit_define_morph_shape_any<W: io::Write>(
 
   let version = if let Some(ref edge_bounds) = &value.edge_bounds {
     let morph_edge_bounds = &value.morph_edge_bounds.unwrap();
-    emit_rect(writer, &edge_bounds)?;
-    emit_rect(writer, &morph_edge_bounds)?;
+    emit_rect(writer, edge_bounds)?;
+    emit_rect(writer, morph_edge_bounds)?;
     #[allow(clippy::identity_op)]
     let flags: u8 = 0
       | (if value.has_scaling_strokes { 1 << 0 } else { 0 })
@@ -609,7 +609,7 @@ pub fn emit_define_shape_any<W: io::Write>(writer: &mut W, value: &ast::tags::De
   emit_le_u16(writer, value.id)?;
   emit_rect(writer, &value.bounds)?;
   let version = if let Some(ref edge_bounds) = &value.edge_bounds {
-    emit_rect(writer, &edge_bounds)?;
+    emit_rect(writer, edge_bounds)?;
     #[allow(clippy::identity_op)]
     let flags: u8 = 0
       | (if value.has_scaling_strokes { 1 << 0 } else { 0 })


### PR DESCRIPTION
This uses the `miniz_oxide` and `lzma-rs` crates to implement `CompressionMethod::{Deflate, Lzma}`, respectively.  
Each compression method is paired with a cargo feature (`deflate`, `lzma`) which is enabled by default, but can be disabled if necessary; this will cause `emit_swf` to return a `SwfEmitError` when trying to emit a SWF with the relevant compression method.

Additionally, `emit_swf(_, CompressionMethod::None)` is specialized to avoid an extra `Vec` copy.