### PR TITLE
[all] Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.14.0 (2022-05-08)
 
 - **[Breaking change]** Update to `swf-types@0.14`.
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "swf-emitter"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "byteorder",
  "half",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-emitter"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF emitter"
 documentation = "https://github.com/open-flash/swf-emitter"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-emitter",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "SWF files emitter",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Update to `swf-types@0.14`.

## Rust

- **[Breaking Change]** `emit_swf` now returns `Result<(), SwfEmitError>` (instead of `Result<(), std::io::Error>`).
- **[Feature]** Add enabled-by-default features `deflate` and `lzma`, they add support for compression methods.

# Typescript

- **[Breaking change]** Compile to `.mjs`.
- **[Fix]** Update dependencies.
- **[Internal]** Use Yarn's Plug'n'Play linker.